### PR TITLE
Compiler pass middlewares

### DIFF
--- a/DependencyInjection/DslMyTargetClientExtension.php
+++ b/DependencyInjection/DslMyTargetClientExtension.php
@@ -90,6 +90,7 @@ class DslMyTargetClientExtension extends ConfigurableExtension
                 $transportDef = $container->getDefinition('dsl.my_target_client.transport.http');
             }
         }
+        $container->setDefinition('dsl.my_target_client.transport.http', $transportDef);
 
         $container->setParameter('dsl.mytarget_client.cache_dir', $mergedConfig['cache_dir']);
 
@@ -121,19 +122,8 @@ class DslMyTargetClientExtension extends ConfigurableExtension
         $container->getDefinition('dsl.my_target_client.cache_control')
                   ->replaceArgument(0, $redisRef);
 
-        // gathering middlewares TODO move to compiles pass
-        $middlewares = [];
-
-        foreach ($container->findTaggedServiceIds('dsl.mytarget_client.middleware') as $def => $tags) {
-            $middlewares[] = $container->getDefinition($def);
-        }
-        $middlewares[] = new Definition(TokenGrantMiddleware::class, [$tokenManagerDef]);
-
-        $middlewareStack = (new Definition())
-            ->setFactory(HttpMiddlewareStackPrototype::class . '::fromArray')
-            ->setArguments([$middlewares, $transportDef]);
-
-        $clientDefinition = new Definition(Client::class, [$requestFactoryDef, $middlewareStack]);
+        $clientDefinition = new Definition(Client::class, [$requestFactoryDef, null]);
+        $clientDefinition->addTag('dsl.mytarget_client.client', ['name' => $clientName]);
         $container->setDefinition('dsl.my_target_client.service.client.' . $clientName, $clientDefinition);
     }
 }

--- a/DependencyInjection/MiddlewaresCollectPass.php
+++ b/DependencyInjection/MiddlewaresCollectPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DSL\MyTargetClientBundle\DependencyInjection;
+
+use Dsl\MyTarget\Token\TokenGrantMiddleware;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class MiddlewaresCollectPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $transportDef = $container->getDefinition('dsl.my_target_client.transport.http');
+        // gathering middlewares TODO move to compiles pass
+        $middlewares = [];
+
+        foreach ($container->findTaggedServiceIds('dsl.mytarget_client.middleware') as $def => $tags) {
+            $middlewares[] = $container->getDefinition($def);
+        }
+        $middlewares[] = new Definition(TokenGrantMiddleware::class, [$tokenManagerDef]);
+
+        $middlewareStack = (new Definition())
+            ->setFactory(HttpMiddlewareStackPrototype::class . '::fromArray')
+            ->setArguments([$middlewares, $transportDef]);
+    }
+}

--- a/DependencyInjection/MiddlewaresCollectPass.php
+++ b/DependencyInjection/MiddlewaresCollectPass.php
@@ -2,7 +2,10 @@
 
 namespace DSL\MyTargetClientBundle\DependencyInjection;
 
+use Dsl\MyTarget\Client;
 use Dsl\MyTarget\Token\TokenGrantMiddleware;
+use Dsl\MyTarget\Transport\Middleware\HttpMiddlewareStackPrototype;
+use DSL\MyTargetClientBundle\DependencyInjection\DslMyTargetClientExtension as Ext;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -11,17 +14,40 @@ class MiddlewaresCollectPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $transportDef = $container->getDefinition('dsl.my_target_client.transport.http');
-        // gathering middlewares TODO move to compiles pass
         $middlewares = [];
-
-        foreach ($container->findTaggedServiceIds('dsl.mytarget_client.middleware') as $def => $tags) {
-            $middlewares[] = $container->getDefinition($def);
+        foreach ($container->findTaggedServiceIds(Ext::PREF . 'middleware') as $def => $tags) {
+            foreach ($tags as $tag) {
+                if (array_key_exists('client', $tag)) {
+                    $middlewares[$tag['client']][$def] = $container->getDefinition($def);
+                } else {
+                    $middlewares['all'][$def] = $container->getDefinition($def);
+                }
+            }
         }
-        $middlewares[] = new Definition(TokenGrantMiddleware::class, [$tokenManagerDef]);
 
-        $middlewareStack = (new Definition())
-            ->setFactory(HttpMiddlewareStackPrototype::class . '::fromArray')
-            ->setArguments([$middlewares, $transportDef]);
+        foreach ($container->findTaggedServiceIds(Ext::PREF . 'client') as $def => $tags) {
+            $client = $container->getDefinition($def);
+            if (Client::class !== $client->getClass()) {
+                continue;
+            }
+            if ( ! isset($tags[0]['name'])) {
+                continue;
+            }
+            $clientName = $tags[0]['name'];
+
+            $tokenManagerDef = $container->getDefinition(sprintf(Ext::TOKEN_MANAGER_DEF_TEMPLATE, $clientName));
+            $tokenAquirerDef = $tokenManagerDef->getArgument(0);
+            $transportDef = $tokenAquirerDef->getArgument(1);
+
+            $allMiddlewares = $middlewares['all'];
+            if (array_key_exists($clientName, $middlewares)) {
+                $allMiddlewares = array_merge($allMiddlewares, $middlewares[$clientName]);
+            }
+            $allMiddlewares[] = new Definition(TokenGrantMiddleware::class, [$tokenManagerDef]);
+            $middlewareStack = (new Definition())
+                ->setFactory(HttpMiddlewareStackPrototype::class . '::fromArray')
+                ->setArguments([$allMiddlewares, $transportDef]);
+            $client->replaceArgument(1, $middlewareStack);
+        }
     }
 }

--- a/DslMyTargetClientBundle.php
+++ b/DslMyTargetClientBundle.php
@@ -1,12 +1,16 @@
 <?php
 
-
 namespace DSL\MyTargetClientBundle;
 
-
+use DSL\MyTargetClientBundle\DependencyInjection\MiddlewaresCollectPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DslMyTargetClientBundle extends Bundle
 {
-
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new MiddlewaresCollectPass());
+    }
 }


### PR DESCRIPTION
To have the ability to gather external middlewares by tag, It was necessary to move this logic to a compiler pass.

Чтобы собирать middleware не только из данного бандла, но и внешние, нужно было вынести это логику в compiler pass.
